### PR TITLE
Add contract-driven page editor

### DIFF
--- a/client/src/core/contracts.js
+++ b/client/src/core/contracts.js
@@ -1,0 +1,17 @@
+import layout from "../../../site/layout.json";
+
+const componentModules = import.meta.glob("../../../contracts/components/*.schema.json", {
+  eager: true,
+});
+
+const components = Object.fromEntries(
+  Object.entries(componentModules).map(([path, mod]) => {
+    const schema = mod.default ?? mod;
+    const id = schema?.$id || path.split("/").pop().replace(/\.schema\.json$/i, "");
+    return [id, schema];
+  })
+);
+
+export const layoutContract = layout;
+export const componentContracts = components;
+export const componentOptions = Object.keys(components).sort();

--- a/client/src/ui/App.jsx
+++ b/client/src/ui/App.jsx
@@ -1,105 +1,183 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { renderDoc } from "../core/ssbPreview.js";
+import { layoutContract, componentContracts, componentOptions } from "../core/contracts.js";
+import { PageEditor } from "./editor/PageEditor.jsx";
 
 const starter = {
-  "title": "MVP Home",
-  "regions": {
-    "header": {
-      "nav": { "type": "Nav@v1", "props": {
-        "items": [
-          { "label": "Home", "href": "#" },
-          { "label": "Docs", "href": "#" },
-          { "label": "Contact", "href": "#" }
-        ],
-        "tw": "text-sm"
-      } }
+  title: "MVP Home",
+  regions: {
+    header: {
+      nav: {
+        type: "Nav@v1",
+        props: {
+          items: [
+            { label: "Home", href: "#" },
+            { label: "Docs", href: "#" },
+            { label: "Contact", href: "#" },
+          ],
+          tw: "text-sm",
+        },
+      },
     },
-    "main": {
-      "_tw": "grid grid-cols-12 gap-8",
-      "hero":   { "type": "Text@v1", "props": { "as":"h1", "text":"Static Site Builder MVP", "tw":"col-span-12 md:col-span-8 text-3xl font-bold" } },
-      "content": [
-        { "type": "Text@v1", "props": { "text":"This page was generated from a JSON contract.", "tw":"col-span-12 md:col-span-8" } },
-        { "type": "Media@v1", "props": { "src":"https://picsum.photos/600/400", "alt":"Hero", "tw":"col-span-12 md:col-span-4 rounded-lg" } },
-        { "type": "Input@v1", "props": { "name":"email", "type":"email", "label":"Join updates", "placeholder":"you@example.com", "tw":"col-span-12 md:col-span-6" } }
-      ]
+    main: {
+      _tw: "grid grid-cols-12 gap-8",
+      hero: {
+        type: "Text@v1",
+        props: {
+          as: "h1",
+          text: "Static Site Builder MVP",
+          tw: "col-span-12 md:col-span-8 text-3xl font-bold",
+        },
+      },
+      content: [
+        {
+          type: "Text@v1",
+          props: {
+            text: "This page was generated from a JSON contract.",
+            tw: "col-span-12 md:col-span-8",
+          },
+        },
+        {
+          type: "Media@v1",
+          props: {
+            src: "https://picsum.photos/600/400",
+            alt: "Hero",
+            tw: "col-span-12 md:col-span-4 rounded-lg",
+          },
+        },
+        {
+          type: "Input@v1",
+          props: {
+            name: "email",
+            type: "email",
+            label: "Join updates",
+            placeholder: "you@example.com",
+            tw: "col-span-12 md:col-span-6",
+          },
+        },
+      ],
     },
-    "footer": {
-      "cta":   { "type": "Text@v1", "props": { "as":"h3", "text":"Ready to ship.", "tw":"text-lg font-semibold" } },
-      "legal": { "type": "Text@v1", "props": { "as":"small", "text":"© 2025 SSB.", "tw":"text-gray-500" } }
-    }
-  }
+    footer: {
+      cta: {
+        type: "Text@v1",
+        props: {
+          as: "h3",
+          text: "Ready to ship.",
+          tw: "text-lg font-semibold",
+        },
+      },
+      legal: {
+        type: "Text@v1",
+        props: {
+          as: "small",
+          text: "© 2025 SSB.",
+          tw: "text-gray-500",
+        },
+      },
+    },
+  },
 };
 
-export default function App(){
-  const [text, setText] = useState(() => JSON.stringify(starter, null, 2));
+const clone = (value) => {
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+};
+
+export default function App() {
+  const [page, setPage] = useState(() => clone(starter));
   const [error, setError] = useState("");
   const iframeRef = useRef(null);
 
-  const docHtml = useMemo(() => {
-    try {
-      const cfg = JSON.parse(text);
-      setError("");
-      return renderDoc(cfg);
-    } catch {
-      setError("Invalid JSON");
-      return renderDoc(starter);
-    }
-  }, [text]);
+  const docHtml = useMemo(() => renderDoc(page), [page]);
 
   useEffect(() => {
     const blob = new Blob([docHtml], { type: "text/html" });
     const url = URL.createObjectURL(blob);
     const el = iframeRef.current;
-    el.src = url;
+    if (el) el.src = url;
     return () => URL.revokeObjectURL(url);
   }, [docHtml]);
 
-  const onLoadFile = async (e) => {
+  const handleLoadFile = async (e) => {
     const f = e.target.files?.[0];
     if (!f) return;
-    const t = await f.text();
-    setText(t);
-  };
-
-  const onDownload = () => {
-    try{
-      const cfg = JSON.parse(text);
-      const blob = new Blob([JSON.stringify(cfg, null, 2)], { type: "application/json" });
-      const a = document.createElement("a");
-      a.href = URL.createObjectURL(blob);
-      a.download = (cfg.title?.toLowerCase().replace(/\s+/g,"-") || "page") + ".json";
-      a.click();
-    } catch {
-      // ignore, editor already shows error
+    try {
+      const text = await f.text();
+      const next = JSON.parse(text);
+      setPage(next);
+      setError("");
+    } catch (err) {
+      console.error(err);
+      setError("Invalid JSON file");
+    } finally {
+      e.target.value = "";
     }
   };
 
+  const handleDownload = () => {
+    const blob = new Blob([JSON.stringify(page, null, 2)], {
+      type: "application/json",
+    });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = `${(page.title || "page").toLowerCase().replace(/\s+/g, "-")}.json`;
+    a.click();
+  };
+
+  const handlePageChange = (next) => {
+    setPage(next);
+    setError("");
+  };
+
   return (
-    <div style={{fontFamily:"ui-sans-serif, system-ui"}}>
-      <header style={{borderBottom:"1px solid #e5e7eb"}}>
-        <div style={{maxWidth: "72rem", margin: "0 auto", padding: "1rem", display:"flex", gap:"0.75rem", alignItems:"center"}}>
-          <h1 style={{fontSize:"1.125rem", fontWeight:600}}>SSB React Client</h1>
-          <input type="file" accept="application/json" onChange={onLoadFile} />
-          <button onClick={onDownload} style={btn()}>Download JSON</button>
-          <button onClick={()=>setText(JSON.stringify(starter, null, 2))} style={btn(true)}>New</button>
-          <span style={{marginLeft:"auto", color:"#6b7280", fontSize:14}}>{error}</span>
+    <div style={{ fontFamily: "ui-sans-serif, system-ui" }}>
+      <header style={{ borderBottom: "1px solid #e5e7eb" }}>
+        <div
+          style={{
+            maxWidth: "72rem",
+            margin: "0 auto",
+            padding: "1rem",
+            display: "flex",
+            gap: "0.75rem",
+            alignItems: "center",
+          }}
+        >
+          <h1 style={{ fontSize: "1.125rem", fontWeight: 600 }}>SSB React Client</h1>
+          <input type="file" accept="application/json" onChange={handleLoadFile} />
+          <button onClick={handleDownload} style={btn()}>
+            Download JSON
+          </button>
+          <button
+            onClick={() => {
+              setPage(clone(starter));
+              setError("");
+            }}
+            style={btn(true)}
+          >
+            New
+          </button>
+          <span style={{ marginLeft: "auto", color: "#6b7280", fontSize: 14 }}>{error}</span>
         </div>
       </header>
 
-      <main style={{maxWidth:"72rem", margin:"0 auto", padding:"1rem"}}>
-        <div style={{display:"grid", gridTemplateColumns:"1fr 1fr", gap:"1.5rem"}}>
-          <section style={panel()}>
-            <div style={panelHead()}>Config</div>
-            <textarea
-              value={text}
-              onChange={e=>setText(e.target.value)}
-              spellCheck={false}
-              style={{width:"100%", height:"65vh", padding:"0.75rem", fontFamily:"ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas", fontSize:12, outline:"none", border:"none"}}
+      <main style={{ maxWidth: "72rem", margin: "0 auto", padding: "1rem" }}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1.5rem" }}>
+          <section style={{ ...panel(), overflow: "auto" }}>
+            <PageEditor
+              page={page}
+              onChange={handlePageChange}
+              layout={layoutContract}
+              components={componentContracts}
+              componentOptions={componentOptions}
             />
           </section>
           <section style={panel()}>
             <div style={panelHead()}>Preview</div>
-            <iframe ref={iframeRef} style={{width:"100%", height:"65vh", background:"#fff", border:"0"}} title="preview" />
+            <iframe
+              ref={iframeRef}
+              style={{ width: "100%", height: "65vh", background: "#fff", border: "0" }}
+              title="preview"
+            />
           </section>
         </div>
       </main>

--- a/client/src/ui/editor/FieldEditor.jsx
+++ b/client/src/ui/editor/FieldEditor.jsx
@@ -1,0 +1,270 @@
+import React from "react";
+
+function fieldLabel(path, schema) {
+  if (schema?.title) return schema.title;
+  const key = path[path.length - 1] || "";
+  return key
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function defaultValueForSchema(schema) {
+  if (!schema) return undefined;
+  if (schema.default !== undefined) return schema.default;
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  switch (type) {
+    case "string":
+      return schema.enum?.[0] ?? "";
+    case "number":
+    case "integer":
+      return 0;
+    case "boolean":
+      return false;
+    case "array":
+      return [];
+    case "object": {
+      const props = schema.properties || {};
+      const required = new Set(schema.required || []);
+      const entries = Object.entries(props)
+        .map(([key, propSchema]) => {
+          const childDefault = defaultValueForSchema(propSchema);
+          if (childDefault === undefined && !required.has(key)) return null;
+          return [key, childDefault];
+        })
+        .filter(Boolean);
+      return Object.fromEntries(entries);
+    }
+    default:
+      return undefined;
+  }
+}
+
+export function FieldEditor({ schema, value, onChange, path = [], required = false }) {
+  if (!schema) return null;
+  const label = fieldLabel(path, schema);
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  const fieldId = path.join("-") || schema.$id || label;
+
+  if (schema.enum && type === "string") {
+    const val = value ?? "";
+    return (
+      <label style={styles.label} htmlFor={fieldId}>
+        <span style={styles.labelText}>{label}{required ? " *" : ""}</span>
+        <select
+          id={fieldId}
+          value={val}
+          onChange={(e) => onChange(e.target.value || (required ? schema.enum[0] : undefined))}
+          style={styles.input}
+        >
+          {!required && <option value="">(none)</option>}
+          {schema.enum.map((opt) => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
+      </label>
+    );
+  }
+
+  if (type === "string") {
+    const val = value ?? "";
+    return (
+      <label style={styles.label} htmlFor={fieldId}>
+        <span style={styles.labelText}>{label}{required ? " *" : ""}</span>
+        <input
+          id={fieldId}
+          type="text"
+          value={val}
+          onChange={(e) => {
+            const next = e.target.value;
+            onChange(next === "" && !required ? undefined : next);
+          }}
+          style={styles.input}
+        />
+      </label>
+    );
+  }
+
+  if (type === "number" || type === "integer") {
+    const val = value ?? "";
+    return (
+      <label style={styles.label} htmlFor={fieldId}>
+        <span style={styles.labelText}>{label}{required ? " *" : ""}</span>
+        <input
+          id={fieldId}
+          type="number"
+          value={val}
+          onChange={(e) => {
+            const next = e.target.value;
+            onChange(next === "" && !required ? undefined : Number(next));
+          }}
+          style={styles.input}
+        />
+      </label>
+    );
+  }
+
+  if (type === "boolean") {
+    const val = Boolean(value);
+    return (
+      <label style={{ ...styles.label, flexDirection: "row", alignItems: "center", gap: "0.5rem" }}>
+        <input
+          type="checkbox"
+          checked={val}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <span style={styles.labelText}>{label}</span>
+      </label>
+    );
+  }
+
+  if (type === "array") {
+    const arr = Array.isArray(value) ? value : [];
+    const itemsSchema = schema.items || {};
+    return (
+      <div style={styles.arrayField}>
+        <div style={styles.arrayHeader}>{label}{required ? " *" : ""}</div>
+        {arr.map((item, idx) => (
+          <div key={idx} style={styles.arrayItem}>
+            <FieldEditor
+              schema={itemsSchema}
+              value={item}
+              onChange={(val) => {
+                const next = [...arr];
+                next[idx] = val;
+                onChange(next);
+              }}
+              path={[...path, String(idx)]}
+              required={true}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                const next = arr.filter((_, i) => i !== idx);
+                onChange(next.length ? next : (required ? [] : undefined));
+              }}
+              style={styles.smallButton}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => {
+            const next = [...arr, defaultValueForSchema(itemsSchema)];
+            onChange(next);
+          }}
+          style={styles.smallButton}
+        >
+          Add Item
+        </button>
+      </div>
+    );
+  }
+
+  if (type === "object") {
+    const props = schema.properties || {};
+    const requiredSet = new Set(schema.required || []);
+    const objVal = value && typeof value === "object" ? value : {};
+    return (
+      <div style={styles.objectField}>
+        {label && path.length > 0 && (
+          <div style={styles.objectHeader}>{label}{required ? " *" : ""}</div>
+        )}
+        <div style={styles.objectBody}>
+          {Object.entries(props).map(([key, propSchema]) => (
+            <FieldEditor
+              key={key}
+              schema={propSchema}
+              value={objVal[key]}
+              onChange={(val) => {
+                const next = { ...objVal };
+                if (val === undefined) {
+                  delete next[key];
+                } else {
+                  next[key] = val;
+                }
+                onChange(Object.keys(next).length ? next : (required ? {} : undefined));
+              }}
+              path={[...path, key]}
+              required={requiredSet.has(key)}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+const styles = {
+  label: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.25rem",
+    fontSize: "0.875rem",
+    color: "#111827",
+  },
+  labelText: {
+    fontWeight: 500,
+  },
+  input: {
+    padding: "0.5rem",
+    border: "1px solid #d1d5db",
+    borderRadius: "0.5rem",
+    fontSize: "0.875rem",
+  },
+  arrayField: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.75rem",
+    padding: "0.75rem",
+    border: "1px solid #e5e7eb",
+    borderRadius: "0.75rem",
+    background: "#f9fafb",
+  },
+  arrayHeader: {
+    fontWeight: 600,
+    fontSize: "0.875rem",
+  },
+  arrayItem: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.5rem",
+    background: "#fff",
+    padding: "0.75rem",
+    borderRadius: "0.75rem",
+    border: "1px solid #e5e7eb",
+  },
+  smallButton: {
+    alignSelf: "flex-start",
+    padding: "0.25rem 0.75rem",
+    borderRadius: "9999px",
+    border: "1px solid #0ea5e9",
+    background: "#0ea5e9",
+    color: "#fff",
+    fontSize: "0.75rem",
+    cursor: "pointer",
+  },
+  objectField: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.75rem",
+    padding: "0.75rem",
+    border: "1px solid #e5e7eb",
+    borderRadius: "0.75rem",
+    background: "#f9fafb",
+  },
+  objectHeader: {
+    fontWeight: 600,
+    fontSize: "0.875rem",
+  },
+  objectBody: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.75rem",
+  },
+};
+
+export { defaultValueForSchema };

--- a/client/src/ui/editor/PageEditor.jsx
+++ b/client/src/ui/editor/PageEditor.jsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { RegionEditor } from "./RegionEditor.jsx";
+
+export function PageEditor({
+  page,
+  onChange,
+  layout,
+  components,
+  componentOptions,
+}) {
+  const regions = page?.regions || {};
+  const layoutRegions = layout?.regions || {};
+  const title = page?.title || "";
+
+  const updatePage = (next) => {
+    onChange({ ...page, ...next });
+  };
+
+  const handleRegionChange = (regionName, regionValue) => {
+    const nextRegions = { ...regions };
+    if (!regionValue || Object.keys(regionValue).length === 0) delete nextRegions[regionName];
+    else nextRegions[regionName] = regionValue;
+    updatePage({ regions: nextRegions });
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>Page</div>
+      <div style={styles.body}>
+        <label style={styles.label}>
+          <span style={styles.labelText}>Title</span>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => updatePage({ title: e.target.value })}
+            style={styles.input}
+          />
+        </label>
+        <div style={styles.regions}>
+          {Object.entries(layoutRegions).map(([regionName, definition]) => (
+            <RegionEditor
+              key={regionName}
+              regionName={regionName}
+              regionValue={regions[regionName]}
+              slots={definition.slots || []}
+              onChange={(value) => handleRegionChange(regionName, value)}
+              components={components}
+              componentOptions={componentOptions}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    border: "1px solid #e5e7eb",
+    borderRadius: "1rem",
+    background: "#fff",
+    overflow: "hidden",
+  },
+  header: {
+    padding: "0.75rem 1rem",
+    borderBottom: "1px solid #e5e7eb",
+    background: "#f9fafb",
+    fontWeight: 600,
+  },
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "1.5rem",
+    padding: "1.5rem",
+  },
+  label: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.25rem",
+    fontSize: "0.875rem",
+    color: "#111827",
+  },
+  labelText: {
+    fontWeight: 500,
+  },
+  input: {
+    padding: "0.5rem",
+    border: "1px solid #d1d5db",
+    borderRadius: "0.5rem",
+    fontSize: "0.875rem",
+  },
+  regions: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "1.5rem",
+  },
+};

--- a/client/src/ui/editor/RegionEditor.jsx
+++ b/client/src/ui/editor/RegionEditor.jsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { SlotEditor } from "./SlotEditor.jsx";
+
+export function RegionEditor({
+  regionName,
+  regionValue,
+  slots = [],
+  onChange,
+  components,
+  componentOptions,
+}) {
+  const value = regionValue && typeof regionValue === "object" ? regionValue : {};
+  const regionTitle = regionName
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+  const tw = value._tw || "";
+
+  const handleSlotChange = (slotName, slotValue) => {
+    const next = { ...value };
+    if (slotValue === undefined) delete next[slotName];
+    else next[slotName] = slotValue;
+    onChange(next);
+  };
+
+  return (
+    <section style={styles.region}>
+      <header style={styles.regionHeader}>
+        <h3 style={styles.regionTitle}>{regionTitle}</h3>
+      </header>
+      <div style={styles.regionBody}>
+        <label style={styles.label}>
+          <span style={styles.labelText}>Region classes (_tw)</span>
+          <input
+            type="text"
+            value={tw}
+            onChange={(e) => {
+              const val = e.target.value;
+              const next = { ...value };
+              if (val) next._tw = val;
+              else delete next._tw;
+              onChange(next);
+            }}
+            style={styles.input}
+          />
+        </label>
+        <div style={styles.slots}>
+          {slots.map((slot) => (
+            <SlotEditor
+              key={slot}
+              slotName={slot}
+              value={value[slot]}
+              onChange={(slotValue) => handleSlotChange(slot, slotValue)}
+              components={components}
+              componentOptions={componentOptions}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const styles = {
+  region: {
+    display: "flex",
+    flexDirection: "column",
+    border: "1px solid #e5e7eb",
+    borderRadius: "1rem",
+    overflow: "hidden",
+    background: "#fff",
+  },
+  regionHeader: {
+    padding: "1rem",
+    borderBottom: "1px solid #e5e7eb",
+    background: "#f9fafb",
+  },
+  regionTitle: {
+    margin: 0,
+    fontSize: "1.125rem",
+  },
+  regionBody: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "1.5rem",
+    padding: "1rem",
+  },
+  label: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.25rem",
+    fontSize: "0.875rem",
+    color: "#111827",
+  },
+  labelText: {
+    fontWeight: 500,
+  },
+  input: {
+    padding: "0.5rem",
+    border: "1px solid #d1d5db",
+    borderRadius: "0.5rem",
+    fontSize: "0.875rem",
+  },
+  slots: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "1rem",
+  },
+};

--- a/client/src/ui/editor/SlotEditor.jsx
+++ b/client/src/ui/editor/SlotEditor.jsx
@@ -1,0 +1,249 @@
+import React from "react";
+import { FieldEditor, defaultValueForSchema } from "./FieldEditor.jsx";
+
+function createComponent(type, schema, previous = {}) {
+  if (!type) return undefined;
+  const base = {
+    type,
+    props: schema ? defaultValueForSchema(schema) || {} : {},
+  };
+  if (previous._wrapTw) base._wrapTw = previous._wrapTw;
+  return base;
+}
+
+function ComponentEditor({
+  component,
+  onChange,
+  onRemove,
+  components,
+  componentOptions,
+  label,
+}) {
+  const current = component && typeof component === "object" ? component : {};
+  const type = current.type || "";
+  const schema = type ? components[type] : null;
+  const propsValue = current.props && typeof current.props === "object" ? current.props : {};
+  const wrapTw = current._wrapTw || "";
+
+  return (
+    <div style={styles.component}>
+      <div style={styles.componentHeader}>
+        <label style={{ ...styles.label, flex: 1 }}>
+          <span style={styles.labelText}>{label}</span>
+          <select
+            value={type}
+            onChange={(e) => {
+              const nextType = e.target.value;
+              if (!nextType) {
+                if (onRemove) onRemove();
+                else onChange(undefined);
+                return;
+              }
+              const nextSchema = components[nextType];
+              onChange(createComponent(nextType, nextSchema, current));
+            }}
+            style={styles.input}
+          >
+            <option value="">Select component</option>
+            {componentOptions.map((opt) => (
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
+        </label>
+        {onRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            style={styles.removeButton}
+          >
+            Remove
+          </button>
+        )}
+      </div>
+
+      {type && (
+        <div style={styles.componentBody}>
+          <label style={styles.label}>
+            <span style={styles.labelText}>Wrapper classes (_wrapTw)</span>
+            <input
+              type="text"
+              value={wrapTw}
+              onChange={(e) => {
+                const val = e.target.value;
+                const next = { ...current, type, props: propsValue };
+                if (val) next._wrapTw = val;
+                else delete next._wrapTw;
+                onChange(next);
+              }}
+              style={styles.input}
+            />
+          </label>
+          {schema ? (
+            <FieldEditor
+              schema={schema}
+              value={propsValue}
+              onChange={(val) => {
+                const next = { ...current, type, props: val ?? {} };
+                if (!val) delete next.props;
+                onChange(next);
+              }}
+              path={[type, "props"]}
+            />
+          ) : (
+            <div style={styles.missingSchema}>No schema found for {type}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SlotEditor({
+  slotName,
+  value,
+  onChange,
+  components,
+  componentOptions,
+}) {
+  const header = slotName.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+  if (Array.isArray(value)) {
+    const arr = value;
+    return (
+      <div style={styles.slot}>
+        <div style={styles.slotHeader}>{header}</div>
+        {arr.map((item, idx) => (
+          <ComponentEditor
+            key={idx}
+            component={item}
+            onChange={(nextComponent) => {
+              if (nextComponent === undefined) {
+                const next = arr.filter((_, i) => i !== idx);
+                onChange(next.length ? next : []);
+              } else {
+                const next = [...arr];
+                next[idx] = nextComponent;
+                onChange(next);
+              }
+            }}
+            onRemove={() => {
+              const next = arr.filter((_, i) => i !== idx);
+              onChange(next.length ? next : []);
+            }}
+            components={components}
+            componentOptions={componentOptions}
+            label={`Item ${idx + 1}`}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={() => {
+            const defaultType = componentOptions[0];
+            if (defaultType) {
+              onChange([
+                ...(arr || []),
+                createComponent(defaultType, components[defaultType] || {}),
+              ]);
+            }
+          }}
+          style={styles.addButton}
+        >
+          Add Component
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.slot}>
+      <div style={styles.slotHeader}>{header}</div>
+      <ComponentEditor
+        component={value}
+        onChange={(nextComponent) => {
+          if (nextComponent === undefined) onChange(undefined);
+          else onChange(nextComponent);
+        }}
+        onRemove={() => onChange(undefined)}
+        components={components}
+        componentOptions={componentOptions}
+        label="Component"
+      />
+    </div>
+  );
+}
+
+const styles = {
+  slot: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "1rem",
+    padding: "1rem",
+    border: "1px solid #e5e7eb",
+    borderRadius: "0.75rem",
+    background: "#fff",
+  },
+  slotHeader: {
+    fontSize: "1rem",
+    fontWeight: 600,
+  },
+  component: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.75rem",
+  },
+  componentHeader: {
+    display: "flex",
+    gap: "0.75rem",
+    alignItems: "flex-end",
+  },
+  componentBody: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.75rem",
+  },
+  label: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.25rem",
+    fontSize: "0.875rem",
+    color: "#111827",
+  },
+  labelText: {
+    fontWeight: 500,
+  },
+  input: {
+    padding: "0.5rem",
+    border: "1px solid #d1d5db",
+    borderRadius: "0.5rem",
+    fontSize: "0.875rem",
+  },
+  removeButton: {
+    padding: "0.25rem 0.75rem",
+    borderRadius: "9999px",
+    border: "1px solid #ef4444",
+    background: "#ef4444",
+    color: "#fff",
+    cursor: "pointer",
+    fontSize: "0.75rem",
+    height: "2.25rem",
+  },
+  addButton: {
+    alignSelf: "flex-start",
+    padding: "0.35rem 0.85rem",
+    borderRadius: "9999px",
+    border: "1px solid #0ea5e9",
+    background: "#0ea5e9",
+    color: "#fff",
+    cursor: "pointer",
+    fontSize: "0.75rem",
+  },
+  missingSchema: {
+    padding: "0.75rem",
+    borderRadius: "0.5rem",
+    background: "#fef3c7",
+    color: "#92400e",
+    fontSize: "0.875rem",
+  },
+};
+
+export { createComponent };

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,14 +1,23 @@
 // client/vite.config.js
-import { defineConfig } from "vite"; 
+import { defineConfig } from "vite";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const rootDir = path.dirname(fileURLToPath(new URL(import.meta.url)));
+const repoRoot = path.resolve(rootDir, "..");
 
 export default defineConfig({
   root: rootDir,
   // Root is the folder containing this config (client/)
-  server: { port: 5173, open: true },
+  server: {
+    port: 5173,
+    open: true,
+    fs: { allow: [repoRoot] },
+  },
   build: { outDir: "dist", emptyOutDir: true },
-  preview: { port: 4173, open: true }
+  preview: {
+    port: 4173,
+    open: true,
+    fs: { allow: [repoRoot] },
+  },
 });


### PR DESCRIPTION
## Summary
- convert the app to manage structured page state and drive the preview from it
- load layout and component contracts to auto-build page, region, slot, and field editors
- wire file import/export to the structured editor and allow Vite to import external JSON

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68e2e9d1752c832a92850e409834cb22