### PR TITLE
Refactor editor into layout tree and property panel

### DIFF
--- a/client/src/ui/App.jsx
+++ b/client/src/ui/App.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { renderDoc } from "../core/ssbPreview.js";
 import { layoutContract, componentContracts, componentOptions } from "../core/contracts.js";
 import { PageEditor } from "./editor/PageEditor.jsx";
+import { PropertiesPanel } from "./editor/PropertiesPanel.jsx";
 
 const starter = {
   title: "MVP Home",
@@ -86,6 +87,7 @@ const clone = (value) => {
 export default function App() {
   const [page, setPage] = useState(() => clone(starter));
   const [error, setError] = useState("");
+  const [selectedPath, setSelectedPath] = useState({ kind: "page" });
   const iframeRef = useRef(null);
 
   const docHtml = useMemo(() => renderDoc(page), [page]);
@@ -106,6 +108,7 @@ export default function App() {
       const next = JSON.parse(text);
       setPage(next);
       setError("");
+      setSelectedPath({ kind: "page" });
     } catch (err) {
       console.error(err);
       setError("Invalid JSON file");
@@ -151,6 +154,7 @@ export default function App() {
             onClick={() => {
               setPage(clone(starter));
               setError("");
+              setSelectedPath({ kind: "page" });
             }}
             style={btn(true)}
           >
@@ -161,14 +165,32 @@ export default function App() {
       </header>
 
       <main style={{ maxWidth: "72rem", margin: "0 auto", padding: "1rem" }}>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1.5rem" }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr 1fr",
+            gap: "1.5rem",
+            alignItems: "start",
+          }}
+        >
           <section style={{ ...panel(), overflow: "auto" }}>
             <PageEditor
+              page={page}
+              layout={layoutContract}
+              components={componentContracts}
+              componentOptions={componentOptions}
+              selectedPath={selectedPath}
+              onSelect={setSelectedPath}
+            />
+          </section>
+          <section style={{ ...panel(), overflow: "auto" }}>
+            <PropertiesPanel
               page={page}
               onChange={handlePageChange}
               layout={layoutContract}
               components={componentContracts}
               componentOptions={componentOptions}
+              selectedPath={selectedPath}
             />
           </section>
           <section style={panel()}>

--- a/client/src/ui/editor/PageEditor.jsx
+++ b/client/src/ui/editor/PageEditor.jsx
@@ -3,49 +3,43 @@ import { RegionEditor } from "./RegionEditor.jsx";
 
 export function PageEditor({
   page,
-  onChange,
   layout,
   components,
   componentOptions,
+  selectedPath,
+  onSelect,
 }) {
   const regions = page?.regions || {};
   const layoutRegions = layout?.regions || {};
-  const title = page?.title || "";
-
-  const updatePage = (next) => {
-    onChange({ ...page, ...next });
-  };
-
-  const handleRegionChange = (regionName, regionValue) => {
-    const nextRegions = { ...regions };
-    if (!regionValue || Object.keys(regionValue).length === 0) delete nextRegions[regionName];
-    else nextRegions[regionName] = regionValue;
-    updatePage({ regions: nextRegions });
-  };
+  const title = page?.title || "Untitled page";
+  const isPageSelected = selectedPath?.kind === "page";
 
   return (
     <div style={styles.container}>
-      <div style={styles.header}>Page</div>
+      <div style={styles.header}>Structure</div>
       <div style={styles.body}>
-        <label style={styles.label}>
-          <span style={styles.labelText}>Title</span>
-          <input
-            type="text"
-            value={title}
-            onChange={(e) => updatePage({ title: e.target.value })}
-            style={styles.input}
-          />
-        </label>
-        <div style={styles.regions}>
+        <button
+          type="button"
+          onClick={() => onSelect?.({ kind: "page" })}
+          style={{
+            ...styles.nodeButton,
+            ...(isPageSelected ? styles.nodeButtonActive : {}),
+          }}
+        >
+          Page: {title || "Untitled"}
+        </button>
+        <div style={styles.regionList}>
           {Object.entries(layoutRegions).map(([regionName, definition]) => (
             <RegionEditor
               key={regionName}
+              mode="outline"
               regionName={regionName}
               regionValue={regions[regionName]}
               slots={definition.slots || []}
-              onChange={(value) => handleRegionChange(regionName, value)}
               components={components}
               componentOptions={componentOptions}
+              selectedPath={selectedPath}
+              onSelect={onSelect}
             />
           ))}
         </div>
@@ -72,28 +66,25 @@ const styles = {
   body: {
     display: "flex",
     flexDirection: "column",
-    gap: "1.5rem",
-    padding: "1.5rem",
+    gap: "1rem",
+    padding: "1.25rem",
   },
-  label: {
+  nodeButton: {
+    textAlign: "left",
+    padding: "0.5rem 0.75rem",
+    borderRadius: "0.75rem",
+    border: "1px solid transparent",
+    background: "transparent",
+    cursor: "pointer",
+    fontSize: "0.95rem",
+  },
+  nodeButtonActive: {
+    borderColor: "#0ea5e9",
+    background: "rgba(14,165,233,0.1)",
+  },
+  regionList: {
     display: "flex",
     flexDirection: "column",
-    gap: "0.25rem",
-    fontSize: "0.875rem",
-    color: "#111827",
-  },
-  labelText: {
-    fontWeight: 500,
-  },
-  input: {
-    padding: "0.5rem",
-    border: "1px solid #d1d5db",
-    borderRadius: "0.5rem",
-    fontSize: "0.875rem",
-  },
-  regions: {
-    display: "flex",
-    flexDirection: "column",
-    gap: "1.5rem",
+    gap: "0.75rem",
   },
 };

--- a/client/src/ui/editor/PropertiesPanel.jsx
+++ b/client/src/ui/editor/PropertiesPanel.jsx
@@ -1,0 +1,243 @@
+import React from "react";
+import { RegionEditor } from "./RegionEditor.jsx";
+import { SlotEditor } from "./SlotEditor.jsx";
+
+function PanelSection({ title, children }) {
+  return (
+    <div style={styles.section}>
+      <div style={styles.sectionHeader}>{title}</div>
+      <div style={styles.sectionBody}>{children}</div>
+    </div>
+  );
+}
+
+export function PropertiesPanel({
+  page,
+  onChange,
+  layout,
+  components,
+  componentOptions,
+  selectedPath,
+}) {
+  const regions = page?.regions || {};
+  const layoutRegions = layout?.regions || {};
+
+  const updatePage = (next) => {
+    onChange({ ...page, ...next });
+  };
+
+  const setRegionValue = (regionName, regionValue) => {
+    const nextRegions = { ...regions };
+    if (!regionValue || Object.keys(regionValue).length === 0) delete nextRegions[regionName];
+    else nextRegions[regionName] = regionValue;
+    updatePage({ regions: nextRegions });
+  };
+
+  const setSlotValue = (regionName, slotName, slotValue) => {
+    const currentRegion = regions[regionName] && typeof regions[regionName] === "object"
+      ? { ...regions[regionName] }
+      : {};
+    if (slotValue === undefined) delete currentRegion[slotName];
+    else currentRegion[slotName] = slotValue;
+    setRegionValue(regionName, currentRegion);
+  };
+
+  const path = selectedPath || { kind: "page" };
+
+  if (path.kind === "page") {
+    const title = page?.title || "";
+    return (
+      <div style={styles.container}>
+        <div style={styles.header}>Properties</div>
+        <div style={styles.body}>
+          <PanelSection title="Page settings">
+            <label style={styles.label}>
+              <span style={styles.labelText}>Title</span>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => updatePage({ title: e.target.value })}
+                style={styles.input}
+              />
+            </label>
+          </PanelSection>
+        </div>
+      </div>
+    );
+  }
+
+  if (path.kind === "region") {
+    const { regionName } = path;
+    const regionDefinition = layoutRegions[regionName];
+    const regionValue = regions[regionName];
+    if (!regionDefinition) {
+      return renderMissing("Region", regionName);
+    }
+    return (
+      <div style={styles.container}>
+        <div style={styles.header}>Properties</div>
+        <div style={styles.body}>
+          <PanelSection title={`Region: ${formatName(regionName)}`}>
+            <RegionEditor
+              mode="properties"
+              regionName={regionName}
+              regionValue={regionValue}
+              slots={regionDefinition.slots || []}
+              onChange={(nextRegion) => setRegionValue(regionName, nextRegion)}
+              components={components}
+              componentOptions={componentOptions}
+            />
+          </PanelSection>
+        </div>
+      </div>
+    );
+  }
+
+  if (path.kind === "slot") {
+    const { regionName, slotName } = path;
+    const regionDefinition = layoutRegions[regionName];
+    const regionValue = regions[regionName];
+    if (!regionDefinition || !(regionDefinition.slots || []).includes(slotName)) {
+      return renderMissing("Slot", `${regionName}.${slotName}`);
+    }
+    const slotValue = regionValue && typeof regionValue === "object" ? regionValue[slotName] : undefined;
+    return (
+      <div style={styles.container}>
+        <div style={styles.header}>Properties</div>
+        <div style={styles.body}>
+          <PanelSection title={`Slot: ${formatName(slotName)}`}>
+            <SlotEditor
+              mode="properties"
+              regionName={regionName}
+              slotName={slotName}
+              value={slotValue}
+              onChange={(nextSlot) => setSlotValue(regionName, slotName, nextSlot)}
+              components={components}
+              componentOptions={componentOptions}
+            />
+          </PanelSection>
+        </div>
+      </div>
+    );
+  }
+
+  if (path.kind === "component") {
+    const { regionName, slotName } = path;
+    const index = path.index ?? undefined;
+    const regionDefinition = layoutRegions[regionName];
+    const regionValue = regions[regionName];
+    if (!regionDefinition || !(regionDefinition.slots || []).includes(slotName)) {
+      return renderMissing("Component", `${regionName}.${slotName}`);
+    }
+    const slotValue = regionValue && typeof regionValue === "object" ? regionValue[slotName] : undefined;
+    if (Array.isArray(slotValue)) {
+      if (typeof index === "number" && (index < 0 || index >= slotValue.length)) {
+        return renderMissing("Component", `${regionName}.${slotName}[${index}]`);
+      }
+    } else if (typeof index === "number") {
+      return renderMissing("Component", `${regionName}.${slotName}`);
+    }
+    return (
+      <div style={styles.container}>
+        <div style={styles.header}>Properties</div>
+        <div style={styles.body}>
+          <PanelSection title={`Component in ${formatName(slotName)}`}>
+            <SlotEditor
+              mode="properties"
+              regionName={regionName}
+              slotName={slotName}
+              value={slotValue}
+              onChange={(nextSlot) => setSlotValue(regionName, slotName, nextSlot)}
+              components={components}
+              componentOptions={componentOptions}
+              focusIndex={index}
+            />
+          </PanelSection>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>Properties</div>
+      <div style={styles.body}>
+        <div style={styles.emptyState}>Select an element to edit its properties.</div>
+      </div>
+    </div>
+  );
+}
+
+function renderMissing(type, name) {
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>Properties</div>
+      <div style={styles.body}>
+        <div style={styles.emptyState}>
+          {type} "{name}" is no longer available in the layout.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatName(name) {
+  return name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const styles = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    border: "1px solid #e5e7eb",
+    borderRadius: "1rem",
+    background: "#fff",
+    overflow: "hidden",
+  },
+  header: {
+    padding: "0.75rem 1rem",
+    borderBottom: "1px solid #e5e7eb",
+    background: "#f9fafb",
+    fontWeight: 600,
+  },
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "1rem",
+    padding: "1.25rem",
+  },
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.75rem",
+  },
+  sectionHeader: {
+    fontWeight: 600,
+    fontSize: "0.95rem",
+  },
+  sectionBody: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "1rem",
+  },
+  label: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.25rem",
+    fontSize: "0.875rem",
+    color: "#111827",
+  },
+  labelText: {
+    fontWeight: 500,
+  },
+  input: {
+    padding: "0.5rem",
+    border: "1px solid #d1d5db",
+    borderRadius: "0.5rem",
+    fontSize: "0.875rem",
+  },
+  emptyState: {
+    fontSize: "0.875rem",
+    color: "#6b7280",
+  },
+};

--- a/client/src/ui/editor/RegionEditor.jsx
+++ b/client/src/ui/editor/RegionEditor.jsx
@@ -8,6 +8,10 @@ export function RegionEditor({
   onChange,
   components,
   componentOptions,
+  mode = "properties",
+  selectedPath,
+  onSelect,
+  focusSlot,
 }) {
   const value = regionValue && typeof regionValue === "object" ? regionValue : {};
   const regionTitle = regionName
@@ -16,37 +20,79 @@ export function RegionEditor({
   const tw = value._tw || "";
 
   const handleSlotChange = (slotName, slotValue) => {
+    if (!onChange) return;
     const next = { ...value };
     if (slotValue === undefined) delete next[slotName];
     else next[slotName] = slotValue;
     onChange(next);
   };
 
+  if (mode === "outline") {
+    const isSelected =
+      selectedPath?.kind === "region" && selectedPath?.regionName === regionName;
+    const visibleSlots = focusSlot ? slots.filter((slot) => slot === focusSlot) : slots;
+
+    return (
+      <div style={outlineStyles.region}>
+        <button
+          type="button"
+          onClick={() => onSelect?.({ kind: "region", regionName })}
+          style={{
+            ...outlineStyles.nodeButton,
+            ...(isSelected ? outlineStyles.nodeButtonActive : {}),
+          }}
+        >
+          {regionTitle}
+        </button>
+        <div style={outlineStyles.slotList}>
+          {visibleSlots.map((slot) => (
+            <SlotEditor
+              key={slot}
+              mode="outline"
+              regionName={regionName}
+              slotName={slot}
+              value={value[slot]}
+              selectedPath={selectedPath}
+              onSelect={onSelect}
+              components={components}
+              componentOptions={componentOptions}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const renderedSlots = focusSlot ? slots.filter((slot) => slot === focusSlot) : slots;
+
   return (
-    <section style={styles.region}>
-      <header style={styles.regionHeader}>
-        <h3 style={styles.regionTitle}>{regionTitle}</h3>
+    <section style={propertyStyles.region}>
+      <header style={propertyStyles.regionHeader}>
+        <h3 style={propertyStyles.regionTitle}>{regionTitle}</h3>
       </header>
-      <div style={styles.regionBody}>
-        <label style={styles.label}>
-          <span style={styles.labelText}>Region classes (_tw)</span>
+      <div style={propertyStyles.regionBody}>
+        <label style={propertyStyles.label}>
+          <span style={propertyStyles.labelText}>Region classes (_tw)</span>
           <input
             type="text"
             value={tw}
             onChange={(e) => {
+              if (!onChange) return;
               const val = e.target.value;
               const next = { ...value };
               if (val) next._tw = val;
               else delete next._tw;
               onChange(next);
             }}
-            style={styles.input}
+            style={propertyStyles.input}
           />
         </label>
-        <div style={styles.slots}>
-          {slots.map((slot) => (
+        <div style={propertyStyles.slots}>
+          {renderedSlots.map((slot) => (
             <SlotEditor
               key={slot}
+              mode="properties"
+              regionName={regionName}
               slotName={slot}
               value={value[slot]}
               onChange={(slotValue) => handleSlotChange(slot, slotValue)}
@@ -60,7 +106,7 @@ export function RegionEditor({
   );
 }
 
-const styles = {
+const propertyStyles = {
   region: {
     display: "flex",
     flexDirection: "column",
@@ -104,5 +150,32 @@ const styles = {
     display: "flex",
     flexDirection: "column",
     gap: "1rem",
+  },
+};
+
+const outlineStyles = {
+  region: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.5rem",
+  },
+  nodeButton: {
+    textAlign: "left",
+    padding: "0.5rem 0.75rem",
+    borderRadius: "0.5rem",
+    border: "1px solid transparent",
+    background: "transparent",
+    cursor: "pointer",
+    fontSize: "0.9rem",
+  },
+  nodeButtonActive: {
+    borderColor: "#0ea5e9",
+    background: "rgba(14,165,233,0.1)",
+  },
+  slotList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.25rem",
+    paddingLeft: "1rem",
   },
 };


### PR DESCRIPTION
## Summary
- add selection tracking in the app and wire it through the layout outline
- split the page editor into a navigation-focused tree and a dedicated properties panel
- enhance region and slot editors to support outline and property editing modes

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68e2f66f5a50832aa7f2723ed43cdde1